### PR TITLE
Allow pass through of http_proxy

### DIFF
--- a/lib/active_zuora/connection.rb
+++ b/lib/active_zuora/connection.rb
@@ -12,6 +12,7 @@ module ActiveZuora
       @session_timeout = configuration[:session_timeout] || 15.minutes
       @soap_client = Savon::Client.new do
         wsdl.document = configuration[:wsdl] || WSDL
+        http.proxy = configuration[:http_proxy] if configuration[:http_proxy]
       end
     end
 


### PR DESCRIPTION
Allow pass through of http_proxy to savon client

Couldn't find a way of dong this cleanly as the gem was, and we needed to be able to configure
