### PR TITLE
Add ability to access session_id from ActiveZuora::Connection

### DIFF
--- a/lib/active_zuora/connection.rb
+++ b/lib/active_zuora/connection.rb
@@ -1,7 +1,7 @@
 module ActiveZuora
   class Connection
 
-    attr_reader :soap_client
+    attr_reader :soap_client, :session_id
 
     WSDL = File.expand_path('../../../wsdl/zuora.wsdl', __FILE__)
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe ActiveZuora::Connection do
+  it { should respond_to(:session_id) }
+  it { should respond_to(:soap_client) }
+end


### PR DESCRIPTION
This could go a step further and add file download as a customization on the Export object.

Example usage;

```
  export = ActiveZuora::Export.new
  export.name = "Test"
  export.format = "csv"
  export.zip = true
  export.query = "SELECT * FROM subscription"

  url = "https://www.zuora.com/apps/api/file/#{export.file_id}"

  id = ActiveZuora::Export.connection.session_id

 Net::HTTP.start(uri.host, uri.port) do |http|
    request = Net::HTTP::Get.new(uri.request_uri)
    request.add_field("Authorization", "ZSession #{id}")

    http.request(request) do |response|
      response.read_body do |chunk|
        src.write(chunk)
      end
    end
  end
```

http://knowledgecenter.zuora.com/D_Zuora_APIs/SOAP_API/C_SOAP_API_Reference/H_Export_ZOQL
http://knowledgecenter.zuora.com/D_Zuora_APIs/SOAP_API/C_SOAP_API_Reference/C_API_Use_Cases_and_Examples/I_Creating_an_Export
