### PR TITLE
Add ability to add custom headers to connection.

### DIFF
--- a/lib/active_zuora/connection.rb
+++ b/lib/active_zuora/connection.rb
@@ -2,6 +2,7 @@ module ActiveZuora
   class Connection
 
     attr_reader :soap_client
+    attr_accessor :custom_header
 
     WSDL = File.expand_path('../../../wsdl/zuora.wsdl', __FILE__)
 
@@ -26,6 +27,8 @@ module ActiveZuora
     def request(*args, &block)
       # instance variables aren't available within the soap request block for some reason.
       header = { 'SessionHeader' => { 'session' => @session_id } }
+      header.merge!(@custom_header) if @custom_header
+
       @soap_client.request(*args) do
         soap.header = header
         yield(soap)

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe ActiveZuora::Connection do
+  context "custom header" do
+    before do
+      @connection = ActiveZuora::Connection.new
+      @stub_was_called = false
+    end
+
+    it "passes the regular header if not set" do
+      Savon::SOAP::Request.stub(:new) do |config, http, soap|
+        @stub_was_called = true
+        soap.header.should == {"SessionHeader" => {"session" => nil}}
+
+        double('response').as_null_object
+      end
+
+      @connection.request(:amend) {}
+
+      @stub_was_called.should eq true
+    end
+
+    it "merges in a custom header if set" do
+      @connection.custom_header = {'CallOptions' => {'useSingleTransaction' => true}}
+      Savon::SOAP::Request.stub(:new) do |config, http, soap|
+        @stub_was_called = true
+        soap.header.should == {"SessionHeader" => {"session" => nil}, 'CallOptions' => {'useSingleTransaction' => true}}
+
+        double('response').as_null_object
+      end
+
+      @connection.request(:amend) {}
+
+      @stub_was_called.should eq true
+    end
+  end
+end


### PR DESCRIPTION
In order to generate certain amendments with Zuora there is a need to pass custom headers, for example 'CallOptions' => {'useSingleTransaction' => true} which we added with this commit.
