### PR TITLE
Upgrade Savon to v1.2.0

### DIFF
--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.license          = "MIT"
   s.extra_rdoc_files = [ "README.md" ]
 
-  s.add_runtime_dependency('savon', ["~> 0.9.9"])
+  s.add_runtime_dependency('savon', ["~> 1.2.0"])
   s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.0.0"])
   s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.0.0"])
 


### PR DESCRIPTION
It appears Savon can be upgraded to 1.x versions without any change. I have tested the change with my project (>1000 Zuora specs).

I'm sceptical if this change is worthwhile though, since this is still a major version behind.