### PR TITLE
[#29] Correctly populate error information

### DIFF
--- a/spec/account_integration_spec.rb
+++ b/spec/account_integration_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'Create Account' do
+
+  integration_test do
+
+    let(:account) do
+      Z::Account.new name: 'Joe Customer',
+                     currency: Tenant.currency,
+                     bill_cycle_day: '1'
+    end
+
+    after(:each) do
+      account.delete unless account.new_record?
+    end
+
+    it 'can create an account' do
+      expect(account).to be_a_new_record
+      expect(account).to_not be_valid
+      expect(account.id).to_not be_present
+      expect(account.errors.full_messages).to eq ["Status can't be blank"]
+
+      now 'update account to be valid' do
+        account.status = 'Draft'
+        expect(account).to be_valid
+        expect(account.errors.full_messages).to be_empty
+      end
+
+      now 'save the account' do
+        expect(account.save).to be true
+        expect(account.id).to be_present
+        expect(account.errors.full_messages).to eq []
+      end
+
+      now 'ensure error messages are accessible' do
+        expect(account.update_attributes status: 'Active').to be false
+        expect(account.errors.full_messages).to eq ['Active account must have both sold to and bill to.']
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ def integration_test
   end
 end
 
+def now(_message)
+  yield
+end
+
 module Tenant
   def self.currency
     ENV['ZUORA_CURRENCY'] || 'USD'


### PR DESCRIPTION
This PR is a suggested fix for https://github.com/sportngin/active_zuora/issues/29

All Zuora request and responses are zipped together instead of manually searched for, which handles the scenario of an error payload not containing a Zuora id.