### PR TITLE
Fix the typo :fields_to_nil -> :fields_to_null

### DIFF
--- a/lib/active_zuora/persistence.rb
+++ b/lib/active_zuora/persistence.rb
@@ -125,7 +125,7 @@ module ActiveZuora
                 :namespace => soap.namespace,
                 :element_name => :zObjects,
                 :force_type => true,
-                :nil_strategy => :fields_to_nil)
+                :nil_strategy => :fields_to_null)
             end.last
           end
         end["#{action.to_s}_response".to_sym][:result]


### PR DESCRIPTION
Fix the typo.

Since `fields_to_null` is used in `lib/persistence.rb` and it fits the api field name in Zuora, I think we should all use `fields_to_null`