### PR TITLE
Fix the fields order when building xml

### DIFF
--- a/lib/active_zuora/base.rb
+++ b/lib/active_zuora/base.rb
@@ -38,8 +38,19 @@ module ActiveZuora
       element_name = custom_element_name || zuora_object_name
       attributes = options.delete(:force_type) ? 
         { "xsi:type" => "#{qualifier}:#{zuora_object_name}" } : {}
+
+      fields_order = lambda do |a, b|
+        if send(a.name) == nil
+          send(b.name) == nil ? 0 : -1
+        elsif a.name.to_sym == :id
+          send(b.name) == nil ? 1 : -1
+        else
+          (b.name.to_sym == :id || send(b.name) == nil) ? 1 : 0
+        end
+      end
+
       xml.tag!(qualifier, element_name.to_sym, attributes) do
-        xml_field_names.map { |field_name| get_field!(field_name) }.each do |field|
+        xml_field_names.map { |field_name| get_field!(field_name) }.sort(&fields_order).each do |field|
           field.build_xml(xml, soap, send(field.name), options)
         end
       end

--- a/lib/active_zuora/base.rb
+++ b/lib/active_zuora/base.rb
@@ -39,20 +39,20 @@ module ActiveZuora
       attributes = options.delete(:force_type) ? 
         { "xsi:type" => "#{qualifier}:#{zuora_object_name}" } : {}
 
-      fields_order = lambda do |a, b|
-        if send(a.name) == nil
-          send(b.name) == nil ? 0 : -1
-        elsif a.name.to_sym == :id
-          send(b.name) == nil ? 1 : -1
-        else
-          (b.name.to_sym == :id || send(b.name) == nil) ? 1 : 0
-        end
-      end
-
       xml.tag!(qualifier, element_name.to_sym, attributes) do
-        xml_field_names.map { |field_name| get_field!(field_name) }.sort(&fields_order).each do |field|
+        xml_field_names.map { |field_name| get_field!(field_name) }.sort(&method(:fields_order)).each do |field|
           field.build_xml(xml, soap, send(field.name), options)
         end
+      end
+    end
+
+    def fields_order(a, b)
+      if send(a.name) == nil
+        send(b.name) == nil ? 0 : -1
+      elsif a.name.to_sym == :id
+        send(b.name) == nil ? 1 : -1
+      else
+        (b.name.to_sym == :id || send(b.name) == nil) ? 1 : 0
       end
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe ActiveZuora::Base do
+  class Comment
+    include ActiveZuora::ZObject
+    field :name, :string
+    field :null_field, :string
+  end
+
+  context "#fields_order" do
+    let(:comment) { Comment.new :id => 'blog1', :null_field => nil, :name => 'test' }
+    let(:field_id) { comment.get_field(:id) }
+    let(:field_null) { comment.get_field(:null_field) }
+    let(:field_name) { comment.get_field(:name) }
+    let(:sorted_fields) { [field_null, field_id, field_name] }
+
+    it 'When the value of a field is null, it should be the first' do
+      fields1 = [field_id, field_null]
+      expect(fields1.sort(&comment.method(:fields_order))).to eq([field_null, field_id])
+
+      fields2 = [field_name, field_null]
+      expect(fields2.sort(&comment.method(:fields_order))).to eq([field_null, field_name])
+
+      fields3 = [field_id, field_name, field_null]
+      expect(fields3.sort(&comment.method(:fields_order))).to eq(sorted_fields)
+    end
+
+    it 'When the field name is id, it should be after the nil value fields but before all other fields' do
+      fields1 = [field_name, field_id]
+      expect(fields1.sort(&comment.method(:fields_order))).to eq([field_id, field_name])
+
+      fields2 = [field_null, field_id]
+      expect(fields2.sort(&comment.method(:fields_order))).to eq([field_null, field_id])
+
+      fields3 = [field_name, field_id, field_null]
+      expect(fields3.sort(&comment.method(:fields_order))).to eq(sorted_fields)
+    end
+  end
+end


### PR DESCRIPTION
Quote from http://goo.gl/AiJeqa (First Comment)

> Please note that the order in which the fieldsToNull field appears in the SOAP request DOES matter.
> The following works:
```xml
<ns1:update>
<ns1:zObjects xsi:type="ns2:PaymentMethod">
<ns2:fieldsToNull>MandateReceived</ns2:fieldsToNull>
<ns2:Id>2c92c0f841ba8ff60141bcc626521637</ns2:Id>
</ns1:zObjects>
</ns1:update>
```
> But having the fieldsToNull field after Id does not.