### PR TITLE
support for batch subscribe requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ You can also delete all records matching a query as well.  The method returns th
 
     ActiveZuora::Account.where(:status => "Draft").delete_all # 56
 
+## Batch Subscribe
+
+You can submit up to 50 subscribe requests on a single subscribe call per the Zuora documentation.  To batch subscribe requests, use the CollectionProxy to build a collection of subscribe requests, then call batch_subscribe
+
+    ActiveZuora::CollectionProxy.new([ActiveZuora::SubscribeRequest.new({account: {}, bill_to: {}, subscription_data:{}}), 
+                                      ActiveZuora::SubscribeRequest.new({account: {}, bill_to: {}, subscription_data:{}})]).batch_subscribe
+
+
 ## License
 
 Active Zuora is released under the MIT license:

--- a/lib/active_zuora.rb
+++ b/lib/active_zuora.rb
@@ -16,6 +16,8 @@ require 'active_zuora/z_object'
 require 'active_zuora/subscribe'
 require 'active_zuora/amend'
 require 'active_zuora/generate'
+require 'active_zuora/batch_subscribe'
+require 'active_zuora/collection_proxy'
 
 module ActiveZuora
 

--- a/lib/active_zuora/batch_subscribe.rb
+++ b/lib/active_zuora/batch_subscribe.rb
@@ -1,0 +1,53 @@
+module ActiveZuora
+  module BatchSubscribe
+
+    # This is meant to be included onto the CollectionProxy class.
+    # Returns true if every SubscribeRequest was a success
+    # Returns false if any single subsciption Request fails
+    # Result hash of each subscribe request is stored in the Subscribe Request #result.
+    # If success, the subscription id and account id will be set in those objects.
+    # If failure, errors will be present on the request object(s) that had error(s).
+    
+    extend ActiveSupport::Concern
+
+    included do
+      include Base
+      attr_accessor :result
+    end
+    
+    def batch_subscribe
+      raise "object must be an ActiveZuora::CollectionProxy object instance" unless self.zuora_object_name == "CollectionProxy"
+      self.result = self.class.connection.request(:subscribe) do |soap|
+        soap.body do |xml| 
+          inject(xml) do |memo, el|
+            el.build_xml(xml, soap, 
+              :namespace => soap.namespace,
+              :element_name => :subscribes,
+              :force_type => true)
+          end
+        end
+      end[:subscribe_response][:result]
+      
+      self.result = [result] unless result.is_a?(Array)
+      result.each_with_index do |result, i|
+        self.records[i].result = result
+        if result[:success]
+          #we assume order is maintained by zuora.  is it?
+          self.records[i].account.id = result[:account_id]
+          self.records[i].subscription_data.subscription.id = result[:subscription_id]
+          self.records[i].clear_changed_attributes
+          @status = true
+        else
+          add_zuora_errors(result[:errors])
+          @status = false
+        end
+      end
+      @status
+    end
+    
+    def batch_subscribe!
+      raise "Could not batch subscribe: #{errors.full_messages.join ', '}" unless batch_subscribe
+    end
+  
+  end
+end

--- a/lib/active_zuora/collection_proxy.rb
+++ b/lib/active_zuora/collection_proxy.rb
@@ -1,0 +1,38 @@
+module ActiveZuora
+  class CollectionProxy
+    
+    include ZObject
+    include Enumerable
+    include BatchSubscribe
+    
+    attr_reader :records, :zobject_class
+
+    def initialize(ary = [])
+      unless ary.empty?
+        raise "objects in collection must be ActiveZuora object instances" unless class_names = ary.map{|object| object.zuora_object_name}.uniq
+        raise "objects in collection must be ActiveZuora object instances of the same class" unless class_names.length == 1
+        @zobject_class = class_names.first
+      end
+      @records = ary
+    end
+    
+    def add object
+      raise "object must be an ActiveZuora object instance" unless object.zuora_object_name
+      if records.empty?
+        @zobject_class = object.zuora_object_name
+      else
+        raise "object must be must be ActiveZuora object instances of the same class as other elements in the Collection" unless object.zuora_object_name == zobject_class
+      end
+      @records.push object
+    end
+
+    def each
+      records.each { |r| yield r }
+    end
+     
+    def empty?
+      records.empty?
+    end
+    
+  end
+end

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -8,6 +8,7 @@ module ActiveZuora
       @document = document
       @classes = []
       @class_nesting = options[:inside] || ActiveZuora
+      @class_nesting.const_set("CollectionProxy", CollectionProxy) unless @class_nesting.constants.include?(:CollectionProxy)
     end
 
     def generate_classes

--- a/spec/collection_proxy_spec.rb
+++ b/spec/collection_proxy_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "ActiveZuora::CollectionProxy" do
+
+  it "should initialize" do
+    cp = Z::CollectionProxy.new
+    expect(cp).to be_empty
+    cp = Z::CollectionProxy.new([Z::SubscribeRequest.new])
+    expect(cp).not_to be_empty
+  end
+
+  it "should respond to enumerable methods" do
+    cp = Z::CollectionProxy.new([Z::SubscribeRequest.new])
+    cp.each do |cp|
+      expect(cp)
+    end
+    cp.inject do |memo,cp|
+      expect(memo)
+      expect(cp)
+    end
+  end
+
+  it "should respond to the batch_subscribe method" do
+    cp = Z::CollectionProxy.new([Z::SubscribeRequest.new])
+    expect(cp.respond_to?(:batch_subscribe)).to eq(true)
+  end
+
+end

--- a/spec/subscribe_integration_spec.rb
+++ b/spec/subscribe_integration_spec.rb
@@ -41,6 +41,7 @@ describe "Subscribe" do
     after do
       @product.delete
       @account.delete
+      @account_2.delete if !!@account_2
     end
 
     it "Can successfully subscribe and amend using a new account" do
@@ -317,6 +318,7 @@ describe "Subscribe" do
       expect(subscribe_request_1.result).to be_present
       
       #subscribe reqeust 2
+      @account_2 = subscribe_request_2.account
       expect(subscribe_request_2.new_record?).to be_falsey
       expect(subscribe_request_2changed?).to be_falsey
       expect(subscribe_request_2.subscription_data.subscription.new_record?).to be_falsey

--- a/spec/subscribe_integration_spec.rb
+++ b/spec/subscribe_integration_spec.rb
@@ -39,8 +39,8 @@ describe "Subscribe" do
     end
 
     after do
-      @account.delete
       @product.delete
+      @account.delete
     end
 
     it "Can successfully subscribe and amend using a new account" do
@@ -212,6 +212,118 @@ describe "Subscribe" do
       invoice.generate!
       expect(invoice.id).to be_present
       expect(invoice.account_id).to eq(subscribe_request.account.id)
+    end
+
+    it "Can successfully batch subscribe from a collection proxy of subscribe requests and generate an invoice for the first subscription" do
+      subscribe_request_1 = Z::SubscribeRequest.new(
+        :account => {
+          :name => "Joe Customer",
+          :currency => Tenant.currency,
+          :bill_cycle_day => 1,
+          :payment_term => "Due Upon Receipt",
+          :batch => "Batch1"
+        },
+        :payment_method => {
+          :type => "CreditCard",
+          :credit_card_holder_name => "Robert Paulson",
+          :credit_card_type => "MasterCard",
+          :credit_card_number => "4111111111111111",
+          :credit_card_expiration_month => 1,
+          :credit_card_expiration_year => (Date.today.year + 1)
+        },
+        :bill_to_contact => {
+          :first_name => "Conny",
+          :last_name => "Client",
+          :work_email => "conny.client@example.com",
+          :country => "AU"
+        },
+        :subscription_data => {
+          :subscription => {
+            :contract_effective_date => Date.today,
+            :service_activation_date => Date.today,
+            :initial_term => 12,
+            :renewal_term => 12,
+            :term_type => 'TERMED'
+          },
+          :rate_plan_data => {
+            :rate_plan => {
+              :product_rate_plan_id => @product_rate_plan.id,
+            },
+            :rate_plan_charge_data => {
+              :rate_plan_charge => {
+                :product_rate_plan_charge_id => @product_rate_plan_charge.id,
+                :price => 45.00
+              }
+            }
+          }
+        }
+      )
+      
+      subscribe_request_2 = Z::SubscribeRequest.new(
+        :account => {
+          :name => "Joe Customer",
+          :currency => Tenant.currency,
+          :bill_cycle_day => 1,
+          :payment_term => "Due Upon Receipt",
+          :batch => "Batch1"
+        },
+        :payment_method => {
+          :type => "CreditCard",
+          :credit_card_holder_name => "Robert Paulson",
+          :credit_card_type => "MasterCard",
+          :credit_card_number => "4111111111111111",
+          :credit_card_expiration_month => 1,
+          :credit_card_expiration_year => (Date.today.year + 1)
+        },
+        :bill_to_contact => {
+          :first_name => "Conny",
+          :last_name => "Client",
+          :work_email => "conny.client@example.com",
+          :country => "AU"
+        },
+        :subscription_data => {
+          :subscription => {
+            :contract_effective_date => Date.today,
+            :service_activation_date => Date.today,
+            :initial_term => 12,
+            :renewal_term => 12,
+            :term_type => 'TERMED'
+          },
+          :rate_plan_data => {
+            :rate_plan => {
+              :product_rate_plan_id => @product_rate_plan.id,
+            },
+            :rate_plan_charge_data => {
+              :rate_plan_charge => {
+                :product_rate_plan_charge_id => @product_rate_plan_charge.id,
+                :price => 45.00
+              }
+            }
+          }
+        }
+      )
+      
+      collection = Z::CollectionProxy.new([subscribe_request_1,subscribe_request_2])
+      collection.batch_subscribe!
+      
+      #subscribe reqeust 1
+      @account = subscribe_request_1.account
+      expect(subscribe_request_1.new_record?).to be_falsey
+      expect(subscribe_request_1changed?).to be_falsey
+      expect(subscribe_request_1.subscription_data.subscription.new_record?).to be_falsey
+      expect(subscribe_request_1.subscription_data.subscription.rate_plans.first.
+        rate_plan_charges.first.
+        product_rate_plan_charge).to eq(@product_rate_plan_charge)
+      expect(subscribe_request_1.result).to be_present
+      
+      #subscribe reqeust 2
+      expect(subscribe_request_2.new_record?).to be_falsey
+      expect(subscribe_request_2changed?).to be_falsey
+      expect(subscribe_request_2.subscription_data.subscription.new_record?).to be_falsey
+      expect(subscribe_request_2.subscription_data.subscription.rate_plans.first.
+        rate_plan_charges.first.
+        product_rate_plan_charge).to eq(@product_rate_plan_charge)
+      expect(subscribe_request_2.result).to be_present
     end
 
   end


### PR DESCRIPTION
Per the Zuora docs https://knowledgecenter.zuora.com/D_SOAP_API/E_SOAP_API_Calls/subscribe_call

The subscribe() call bundles the information required to create one or more new subscriptions.

This pr aims to support creating multiple subscriptions at once.

The approach is to use a CollectionProxy - analogous to an ActiveRecord::Associations::CollectionProxy that includes a BatchSubscribe module.  The BatchSubscribe module has a batch_subscribe method that builds a subscribe xml from a collection.
