### PR TITLE
Remove body from invoices

### DIFF
--- a/lib/active_zuora/generate.rb
+++ b/lib/active_zuora/generate.rb
@@ -39,5 +39,19 @@ module ActiveZuora
       raise "Could not generate: #{errors.full_messages.join ', '}" unless generate
     end
 
+    # Access the pdf representation of the invoice that is usually stored in the body field.
+    def pdf
+      return '' if new_record?
+      @pdf ||= fetch_pdf
+    end
+
+    protected
+
+    def fetch_pdf
+      response = self.class.connection.request(:query) do |soap|
+        soap.body = { :query_string => "select Body from #{self.class.zuora_object_name} where Id = '#{id}'" }
+      end
+      response[:query_response][:result][:records][:body]
+    end
   end
 end

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -143,7 +143,10 @@ module ActiveZuora
 
       customize 'Invoice' do
         include Generate
-        exclude_from_queries :regenerate_invoice_pdf
+        # The body field can only be accessed for a single invoice at a time, so
+        # exclude it here to not break collections of invoices. The contents of
+        # the body field can be accessed instead through the pdf method.
+        exclude_from_queries :regenerate_invoice_pdf, :body
       end
 
       customize 'InvoiceItemAdjustment' do


### PR DESCRIPTION
The Zuora API only allows fetching the body field on a single invoice at a time
which breaks fetching collections of invoices.

This removes the body field from regular queries, allowing collections to be
fetched without errors. In order to allow the PDF of the invoice (which is
normally stored in the body) to be accessed without having to write a specific
query, this also adds a `pdf` method to invoices.