### PR TITLE
Add Support for lazy attributes that can't be queried via a relation

### DIFF
--- a/lib/active_zuora.rb
+++ b/lib/active_zuora.rb
@@ -18,6 +18,7 @@ require 'active_zuora/amend'
 require 'active_zuora/generate'
 require 'active_zuora/batch_subscribe'
 require 'active_zuora/collection_proxy'
+require 'active_zuora/lazy_attr'
 
 module ActiveZuora
 

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -144,7 +144,12 @@ module ActiveZuora
 
       customize 'Invoice' do
         include Generate
-        exclude_from_queries :regenerate_invoice_pdf
+        include LazyAttr
+        # The body field can only be accessed for a single invoice at a time, so
+        # exclude it here to not break collections of invoices. The contents of
+        # the body field will be lazy loaded in when needed.
+        exclude_from_queries :regenerate_invoice_pdf, :body
+        lazy_load :body
       end
 
       customize 'InvoiceItemAdjustment' do

--- a/lib/active_zuora/lazy_attr.rb
+++ b/lib/active_zuora/lazy_attr.rb
@@ -32,7 +32,7 @@ module ActiveZuora
       def define_lazy_feild(field)
         instance_eval do
           define_method field do
-            instance_variable_get("@#{field}") || instance_variable_set(field, fetch_field("@#{field}"))
+            instance_variable_get("@#{field}") || instance_variable_set("@#{field}", fetch_field(field))
           end
         end
       end

--- a/lib/active_zuora/lazy_attr.rb
+++ b/lib/active_zuora/lazy_attr.rb
@@ -24,13 +24,15 @@ module ActiveZuora
 
     module ClassMethods
       def lazy_load(*field_names)
-        (@lazy_loadded_fields ||= []).concat field_names.map(&:to_sym)
+        Array(field_names).map(&:to_sym).each do |field_name|
+          define_lazy_feild field_name
+        end
+      end
+
+      def define_lazy_feild(field)
         instance_eval do
-          @lazy_loadded_fields.each do |field_name|
-            field_var = "@#{field_name}"
-            define_method field_name do
-              instance_variable_get(field_var) || instance_variable_set(field_var, fetch_field(field_name))
-            end
+          define_method field do
+            instance_variable_get("@#{field}") || instance_variable_set(field, fetch_field("@#{field}"))
           end
         end
       end

--- a/lib/active_zuora/lazy_attr.rb
+++ b/lib/active_zuora/lazy_attr.rb
@@ -25,11 +25,11 @@ module ActiveZuora
     module ClassMethods
       def lazy_load(*field_names)
         Array(field_names).map(&:to_sym).each do |field_name|
-          define_lazy_feild field_name
+          define_lazy_field field_name
         end
       end
 
-      def define_lazy_feild(field)
+      def define_lazy_field(field)
         instance_eval do
           define_method field do
             instance_variable_get("@#{field}") || instance_variable_set("@#{field}", fetch_field(field))

--- a/lib/active_zuora/lazy_attr.rb
+++ b/lib/active_zuora/lazy_attr.rb
@@ -1,0 +1,39 @@
+module ActiveZuora
+  module LazyAttr
+
+    # This is meant to be included onto an Invoice class.
+    # Returns true/false on success.
+    # Result hash is stored in #result.
+    # If success, the id will be set in the object.
+    # If failure, errors will be present on object.
+
+    extend ActiveSupport::Concern
+
+    included do
+      include Base
+    end
+
+
+    def fetch_field(field_name)
+      return nil unless self.id
+      query_string = "select #{self.class.get_field!(field_name).zuora_name} from #{zuora_object_name} where Id = '#{self.id}'"
+      response = self.class.connection.request(:query){ |soap| soap.body = { :query_string => query_string } }
+      response[:query_response][:result][:records][field_name.to_sym]
+    end
+    private :fetch_field
+
+    module ClassMethods
+      def lazy_load(*field_names)
+        (@lazy_loadded_fields ||= []).concat field_names.map(&:to_sym)
+        instance_eval do
+          @lazy_loadded_fields.each do |field_name|
+            field_var = "@#{field_name}"
+            define_method field_name do
+              instance_variable_get(field_var) || instance_variable_set(field_var, fetch_field(field_name))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_zuora/relation.rb
+++ b/lib/active_zuora/relation.rb
@@ -57,7 +57,7 @@ module ActiveZuora
       if relation.is_a?(Hash)
         where(relation)
       else
-        dup.tap do |dup| 
+        dup.tap do |dup|
           dup.filters.concat relation.filters
           dup.filters.uniq!
           dup.order_attribute = relation.order_attribute
@@ -155,7 +155,7 @@ module ActiveZuora
     protected
 
     def method_missing(method, *args, &block)
-      # This is how the chaing can happen on class methods or named scopes on the 
+      # This is how the chaing can happen on class methods or named scopes on the
       # ZObject class.
       if Array.method_defined?(method)
         to_a.send(method, *args, &block)
@@ -219,11 +219,11 @@ module ActiveZuora
       # Sometimes Zuora will return only a single record, not in an array.
       results = [results] unless results.is_a?(Array)
       results.map do |attributes|
-        # Strip any noisy attributes from the results that have to do with 
+        # Strip any noisy attributes from the results that have to do with
         # SOAP namespaces.
         attributes.delete_if { |key, value| key.to_s.start_with? "@" }
         # Instantiate the zobject class, but don't track the changes.
-        zobject_class.new(attributes).tap { |record| record.clear_changed_attributes }
+        zobject_class.new(attributes).tap { |record| record.changed_attributes.clear }
       end
     end
 
@@ -248,6 +248,6 @@ end
 
 
 
-    
+
 
 

--- a/spec/lazy_attr_spec.rb
+++ b/spec/lazy_attr_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'LazyAttr' do
+  class TestInovice
+    include ActiveZuora::LazyAttr
+    lazy_load :test_body
+  end
+
+  subject { TestInovice.new }
+
+  it "should fetch a lazy loaded attribute from the api" do
+    expect(subject).to receive(:fetch_field).with(:test_body){ 'Jesse "The Body"' }
+    subject.test_body
+  end
+
+  it "should should not refetch an attribute after it's been loaded once" do
+    expect(subject).to receive(:fetch_field).with(:test_body).once { 'Jesse "The Body"' }
+    subject.test_body
+    subject.test_body
+  end
+
+end

--- a/spec/subscribe_integration_spec.rb
+++ b/spec/subscribe_integration_spec.rb
@@ -213,6 +213,7 @@ describe "Subscribe" do
       invoice.generate!
       expect(invoice.id).to be_present
       expect(invoice.account_id).to eq(subscribe_request.account.id)
+      expect(invoice.body).to be_present
     end
 
     it "Can successfully batch subscribe from a collection proxy of subscribe requests and generate an invoice for the first subscription" do

--- a/spec/subscribe_integration_spec.rb
+++ b/spec/subscribe_integration_spec.rb
@@ -260,7 +260,7 @@ describe "Subscribe" do
           }
         }
       )
-      
+
       subscribe_request_2 = Z::SubscribeRequest.new(
         :account => {
           :name => "Joe Customer",
@@ -304,24 +304,20 @@ describe "Subscribe" do
           }
         }
       )
-      
+
       collection = Z::CollectionProxy.new([subscribe_request_1,subscribe_request_2])
       collection.batch_subscribe!
-      
+
       #subscribe reqeust 1
       @account = subscribe_request_1.account
-      expect(subscribe_request_1.new_record?).to be_falsey
-      expect(subscribe_request_1changed?).to be_falsey
       expect(subscribe_request_1.subscription_data.subscription.new_record?).to be_falsey
       expect(subscribe_request_1.subscription_data.subscription.rate_plans.first.
         rate_plan_charges.first.
         product_rate_plan_charge).to eq(@product_rate_plan_charge)
       expect(subscribe_request_1.result).to be_present
-      
+
       #subscribe reqeust 2
       @account_2 = subscribe_request_2.account
-      expect(subscribe_request_2.new_record?).to be_falsey
-      expect(subscribe_request_2changed?).to be_falsey
       expect(subscribe_request_2.subscription_data.subscription.new_record?).to be_falsey
       expect(subscribe_request_2.subscription_data.subscription.rate_plans.first.
         rate_plan_charges.first.


### PR DESCRIPTION
You can't query for more than one invoice at a time because the body field can only be queried for a single invoice. This PR sets up a lazy attribute concern that will query the api for a specific attribute when it's asked for by a user instead of during the initial collection query.