### PR TITLE
Fix #43 - Add invoice_payment_data to exclusions list

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -158,7 +158,7 @@ module ActiveZuora
 
       customize 'Payment' do
         exclude_from_queries :applied_invoice_amount,
-          :gateway_option_data, :invoice_id, :invoice_number
+          :gateway_option_data, :invoice_id, :invoice_number, :invoice_payment_data
       end
 
       customize 'PaymentMethod' do


### PR DESCRIPTION
The invoice payment data field on Payments is not valid for queries and was causing errors. This adds it to the exclusions list.