### PR TITLE
Lazy load Active Currencies on Product Rate Plans

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -167,6 +167,12 @@ module ActiveZuora
           :second_token_id, :skip_validation, :token_id
       end
 
+      customize 'ProductRatePlan' do
+        include LazyAttr
+        exclude_from_queries :active_currencies
+        lazy_load :active_currencies
+      end
+
       customize 'ProductRatePlanCharge' do
         exclude_from_queries :product_rate_plan_charge_tier_data
       end


### PR DESCRIPTION
Product Rate Plans must query for the Active Currencies field by itself. This excludes the field from normal queries and lazy loads it instead.