### PR TITLE
Lazy load price.

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -184,8 +184,7 @@ module ActiveZuora
       customize 'RatePlanCharge' do
         include LazyAttr
         exclude_from_queries :overage_price, :included_units,
-          :discount_amount, :discount_percentage, :price, :rollover_balance
-
+          :discount_amount, :discount_percentage, :rollover_balance, :price
         lazy_load :price
       end
 

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -182,12 +182,11 @@ module ActiveZuora
       end
 
       customize 'RatePlanCharge' do
-        exclude_from_queries :rollover_balance
-        # Can only use overageprice or price or includedunits or
-        # discountamount or discountpercentage in one query.
-        # We'll pick price.
+        include LazyAttr
         exclude_from_queries :overage_price, :included_units,
-          :discount_amount, :discount_percentage
+          :discount_amount, :discount_percentage, :price, :rollover_balance
+
+        lazy_load :price
       end
 
       customize 'Refund' do

--- a/lib/active_zuora/lazy_attr.rb
+++ b/lib/active_zuora/lazy_attr.rb
@@ -16,11 +16,22 @@ module ActiveZuora
 
     def fetch_field(field_name)
       return nil unless self.id
-      query_string = "select #{self.class.get_field!(field_name).zuora_name} from #{zuora_object_name} where Id = '#{self.id}'"
-      response = self.class.connection.request(:query){ |soap| soap.body = { :query_string => query_string } }
-      response[:query_response][:result][:records][field_name.to_sym]
+
+      records = fetch_field_records("select #{self.class.get_field!(field_name).zuora_name} from #{zuora_object_name} where Id = '#{self.id}'")
+      type_cast_fetched_field(field_name, records.nil? ? nil : records[field_name.to_sym])
     end
     private :fetch_field
+
+    def fetch_field_records(query_string)
+      response = self.class.connection.request(:query){ |soap| soap.body = { :query_string => query_string } }
+      response[:query_response][:result][:records]
+    end
+    private :fetch_field_records
+
+    def type_cast_fetched_field(field_name, value)
+      get_field!(field_name).type_cast(value)
+    end
+    private :type_cast_fetched_field
 
     module ClassMethods
       def lazy_load(*field_names)


### PR DESCRIPTION
Per the Zuora documentation (source: http://knowledgecenter.zuora.com/BC_Developers/SOAP_API/E1_SOAP_API_Object_Reference/RatePlanCharge):

`You can query for Price from a RatePlanCharge object unless the charge model is volume or tiered pricing. If the charged model is volume or tiered pricing, then you need to query for Price from the relevant RatePlanChargeTier.
`

What they fail to mention is when you include `Price` in a query to the Rate Plan Charge object, volume and tiered Rate plan charges will fail to be returned, not just not include a price attribute. I have made price a lazily loaded attribute to all Rate Plan Charges should be treated equally.

I think we might need to further wrap this to consistently return price no matter what the charge model.