### PR TITLE
Exclude RevenueRecogntionRuleName from queries on RatePlanCharge

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -184,7 +184,7 @@ module ActiveZuora
       customize 'RatePlanCharge' do
         include LazyAttr
         exclude_from_queries :overage_price, :included_units,
-          :discount_amount, :discount_percentage, :rollover_balance, :price
+          :discount_amount, :discount_percentage, :rollover_balance, :price, :revenue_recognition_rule_name
         lazy_load :price
       end
 


### PR DESCRIPTION
Fix for issue #48 
