### PR TITLE
Make the query method use the correct query_locator

### DIFF
--- a/lib/active_zuora/relation.rb
+++ b/lib/active_zuora/relation.rb
@@ -120,7 +120,7 @@ module ActiveZuora
       # them until done.
       until query_response[:result][:done]
         query_response = zobject_class.connection.request(:query_more) do |soap|
-          soap.body = { :query_locator => response[:query_response][:result][:query_locator] }
+          soap.body = { :query_locator => query_response[:result][:query_locator] }
         end[:query_more_response]
         more_records = objectify_query_results(query_response[:result][:records])
         more_records.each(&:block) if block_given?


### PR DESCRIPTION
The `response[:query_response][:result][:query_locator]` locator never changes - it always points to the second page. If there are more than 4k accounts in Zuora, the query method will keep loading the second page endlessly.

The correct `query_locator` to be used there is `query_response[:result][:query_locator]` which points to the next page, not to the second.
