### PR TITLE
Exclude invoice bill_run_id from query

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -148,7 +148,7 @@ module ActiveZuora
         # The body field can only be accessed for a single invoice at a time, so
         # exclude it here to not break collections of invoices. The contents of
         # the body field will be lazy loaded in when needed.
-        exclude_from_queries :regenerate_invoice_pdf, :body
+        exclude_from_queries :regenerate_invoice_pdf, :body, :bill_run_id
         lazy_load :body
       end
 


### PR DESCRIPTION
Zuora added the BillRunId attribute as a filter to [Invoices](https://knowledgecenter.zuora.com/BC_Developers/SOAP_API/E1_SOAP_API_Object_Reference/Invoice) in WSDL 66.0. This PR excludes this attribute from queries.