### PR TITLE
Do not pass time zone offset

### DIFF
--- a/lib/active_zuora/fields/date_time_field.rb
+++ b/lib/active_zuora/fields/date_time_field.rb
@@ -11,7 +11,7 @@ module ActiveZuora
       # All dates need to be in PST time.  Since all user-set attributes
       # in Zuora are really only dates, we'll chop off the time.
       # 2012-05-22T00:00:00-08:00
-      value = value ? value.strftime("%Y-%m-%dT00:00:00-08:00") : ''
+      value = value ? value.strftime("%Y-%m-%dT00:00:00") : ''
       super(xml, soap, value, options)
     end
 


### PR DESCRIPTION
We are seeing that now when we upload our daily usage, that it is showing up at 1am instead of midnight.

Found out that Zuora switched over to using daylight savings time: https://knowledgecenter.zuora.com/CB_Billing/WA_Dates_in_Zuora/A_Date_and_dateTime_Format

They've suggested best practice is to just pass a datetime without a timezone offset:

```
When passing a dateTime value to a field, do not pass a time zone offset component. For example: 
 * The preferred format for passing a dateTime value is: 2011-01-01T03:18:09
  * Do not pass a value like this: 2011-01-01T03:18:09-08:00
```

Also a heads up that with WSDL 69 they are adding "date" fields for some objects. That is not covered in this PR though.
