### PR TITLE
Adds Date Field

### DIFF
--- a/lib/active_zuora/fields.rb
+++ b/lib/active_zuora/fields.rb
@@ -1,5 +1,6 @@
 require 'active_zuora/fields/field'
 require 'active_zuora/fields/boolean_field'
+require 'active_zuora/fields/date_field'
 require 'active_zuora/fields/date_time_field'
 require 'active_zuora/fields/decimal_field'
 require 'active_zuora/fields/integer_field'
@@ -14,7 +15,7 @@ module ActiveZuora
 
     included do
       include ActiveModel::Dirty
-      delegate :fields, :field_names, :field?, :get_field, :get_field!, 
+      delegate :fields, :field_names, :field?, :get_field, :get_field!,
         :default_attributes, :to => 'self.class'
     end
 
@@ -96,10 +97,11 @@ module ActiveZuora
         field_is_array = options.delete(:array) || false
         # Create and register the field.
         field = case type
-          when :string then StringField.new(name, namespace, options)
-          when :boolean then BooleanField.new(name, namespace, options)
-          when :integer then IntegerField.new(name, namespace, options)
-          when :decimal then DecimalField.new(name, namespace, options)
+          when :string   then StringField.new(name, namespace, options)
+          when :boolean  then BooleanField.new(name, namespace, options)
+          when :integer  then IntegerField.new(name, namespace, options)
+          when :decimal  then DecimalField.new(name, namespace, options)
+          when :date     then DateField.new(name, namespace, options)
           when :datetime then DateTimeField.new(name, namespace, options)
           when :object
             class_name = options[:class_name] || nested_class_name(name.to_s.camelize)

--- a/lib/active_zuora/fields/date_field.rb
+++ b/lib/active_zuora/fields/date_field.rb
@@ -1,0 +1,18 @@
+module ActiveZuora
+  class DateField < Field
+
+    def type_cast(value)
+      return value if value.nil?
+      return value.to_date if value.is_a?(Date)
+      return value.to_date if value.is_a?(DateTime)
+      value.to_date rescue default
+    end
+
+    def build_xml(xml, soap, value, options={})
+      value = value ? value.strftime("%Y-%m-%d") : ''
+      super(xml, soap, value, options)
+    end
+
+  end
+end
+

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -64,6 +64,9 @@ module ActiveZuora
             when "decimal"
               zuora_class.field field_name, :decimal,
                 :zuora_name => zuora_name, :array => is_array
+            when "date"
+              zuora_class.field field_name, :date,
+                :zuora_name => zuora_name, :array => is_array
             when "dateTime"
               zuora_class.field field_name, :datetime,
                 :zuora_name => zuora_name, :array => is_array

--- a/lib/active_zuora/version.rb
+++ b/lib/active_zuora/version.rb
@@ -1,3 +1,3 @@
 module ActiveZuora
-  VERSION = "2.2.7"
+  VERSION = "2.2.8"
 end

--- a/spec/fields/date_field_spec.rb
+++ b/spec/fields/date_field_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe ActiveZuora::DateField do
+  subject { described_class.new("date", described_class, {:zuora_name => "date"}) }
+
+  describe "#type_cast" do
+    it "returns nil if provided nil" do
+      expect(subject.type_cast(nil)).to eq(nil)
+    end
+
+    it "returns a date when given a datetime object" do
+      datetime = DateTime.now
+      expect(subject.type_cast(datetime)).to be_a(Date)
+    end
+
+    it "returns a date when given a date object" do
+      date = Date.today
+      expect(subject.type_cast(date)).to be_a(Date)
+    end
+  end
+
+  describe "#build_xml" do
+    let(:xml)  { double(:xml, :tag! => nil) }
+    let(:soap) { double(:soap, :namespace_by_uri => nil) }
+    let(:options) { {} }
+
+    it "handles a nil value" do
+      expect { subject.build_xml(xml, soap, nil, options) }.to_not raise_error
+    end
+
+    it "handles a date value" do
+      expect { subject.build_xml(xml, soap, Date.today, options) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
The Zuora wsdl version 69 allows for a `date` field. This PR adds support for a `date` field in order to prevent errors for users of this gem that upgrade to the latest wsdl version.