### PR TITLE
Capitalize first letter of wsdl object name

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,5 @@
+#### v2.3.0
+*  Add billing preview capability and exclude price from rate plan charge queries
 #### v2.2.0.1
 *  Capitalize first letter of wsdl object name to ensure that it is a valid Ruby constant
 #### v2.2.0

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,5 @@
+#### v2.2.0.1
+*  Capitalize first letter of wsdl object name to ensure that it is a valid Ruby constant
 #### v2.2.0
 #### v2.1.4
 #### v2.1.3

--- a/lib/active_zuora.rb
+++ b/lib/active_zuora.rb
@@ -16,6 +16,7 @@ require 'active_zuora/z_object'
 require 'active_zuora/subscribe'
 require 'active_zuora/amend'
 require 'active_zuora/generate'
+require 'active_zuora/billing_preview'
 require 'active_zuora/batch_subscribe'
 require 'active_zuora/collection_proxy'
 

--- a/lib/active_zuora/billing_preview.rb
+++ b/lib/active_zuora/billing_preview.rb
@@ -1,0 +1,49 @@
+module ActiveZuora
+  module BillingPreview
+
+    # This is meant to be included onto an BillingPreviewRequest class.
+    # Returns a BillingPreviewResponse object on success.
+    # Result hash is stored in #result.
+    # If failure, errors will be present on object.
+
+    extend ActiveSupport::Concern
+
+    included do
+      include Base
+      attr_accessor :result
+    end
+
+    def billing_preview
+      self.result = self.class.connection.request(:billing_preview) do |soap|
+        soap.body do |xml|
+          build_xml(xml, soap,
+            :namespace => soap.namespace,
+            :element_name => :requests,
+            :force_type => true)
+        end
+      end[:billing_preview_response][:results]
+
+      if result[:success]
+        clear_changed_attributes
+        filtered_invoice_items = self.result[:invoice_item].map do |invoice_item|
+          #Filter out data in the return value that are not valid invoice item fields such as
+          #    :"@xmlns:ns2"=>"http://object.api.zuora.com/",
+          #    :"@xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance",
+          #    :"@xsi:type"=>"ns2:InvoiceItem"
+          invoice_item.select{|key, v| ActiveZuora::InvoiceItem.field_names.include?(key)}
+        end
+        ActiveZuora::BillingPreviewResult.new(self.result.merge(invoice_item: filtered_invoice_items))
+      else
+        add_zuora_errors(result[:errors])
+        false
+      end
+    end
+
+    def billing_preview!
+      billing_preview.tap do |preview|
+        raise "Could not billing preview: #{errors.full_messages.join ', '}" unless preview
+      end
+    end
+
+  end
+end

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -30,6 +30,7 @@ module ActiveZuora
           # Skip the zObject base class, we define our own.
           next if class_name == "zObject"
 
+          class_name[0] = class_name[0].upcase
           zuora_class = Class.new
           @class_nesting.const_set(class_name, zuora_class)
           @classes << zuora_class

--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -73,7 +73,7 @@ module ActiveZuora
                 :zuora_name => zuora_name, :array => is_array,
                 :class_name => zuora_class.nested_class_name(field_type.split(':').last)
             else
-              puts "Unkown field type: #{field_type}"
+              puts "Unknown field type: #{field_type}"
             end
           end # each element
 
@@ -148,6 +148,10 @@ module ActiveZuora
         exclude_from_queries :regenerate_invoice_pdf
       end
 
+      customize 'BillingPreviewRequest' do
+        include BillingPreview
+      end
+
       customize 'InvoiceItemAdjustment' do
         exclude_from_queries :customer_name, :customer_number
       end
@@ -177,7 +181,7 @@ module ActiveZuora
         # discountamount or discountpercentage in one query.
         # We'll pick price.
         exclude_from_queries :overage_price, :included_units,
-          :discount_amount, :discount_percentage
+          :discount_amount, :discount_percentage, :price
       end
 
       customize 'Refund' do

--- a/lib/active_zuora/version.rb
+++ b/lib/active_zuora/version.rb
@@ -1,3 +1,3 @@
 module ActiveZuora
-  VERSION = "2.2.0.1"
+  VERSION = "2.3.0"
 end

--- a/lib/active_zuora/version.rb
+++ b/lib/active_zuora/version.rb
@@ -1,3 +1,3 @@
 module ActiveZuora
-  VERSION = "2.1.4"
+  VERSION = "2.2.0.1"
 end


### PR DESCRIPTION
 Capitalize first letter of wsdl object name to ensure that it is a valid Ruby constant.  An optional feature, [BillingPreview](https://knowledgecenter.zuora.com/BC_Developers/SOAP_API/E_SOAP_API_Calls/BillingPreview_call) adds types to the wsdl with a lowercase name.  An error is raised when running ActiveZuora.generate_classes because ruby constants must start with a capital letter.  I have a request in to Zuora to fix, but active zuora should be able to handle this without crashing.

This doesn't necessarily enable the billingPreview action to be implemented. It's a work around in order to get a parseable wsdl and could need modified in order to fully implement this feature.

See the offending wsdl snippet below:

```xml
<complexType name="calculateRequest">
	<sequence>
		<element minOccurs="1" maxOccurs="1" name="chargeId" type="string" />
	</sequence>
</complexType>
<complexType name="calculateResult">
	<sequence>
		<element minOccurs="1" maxOccurs="1" name="Success" type="boolean" />
		<element minOccurs="1" maxOccurs="1" name="Size" nillable="true" type="int" />
		<element minOccurs="0" maxOccurs="unbounded" name="Error" nillable="true" type="zns:ChargeMetricsError" />
		<element minOccurs="0" maxOccurs="unbounded" name="ChargeMetrics" type="ons:ChargeMetrics" />
	</sequence>
</complexType>
```