### PR TITLE
Add product_rate_plan_charge_id to exclusion list for InvoiceItem

### DIFF
--- a/lib/active_zuora/generator.rb
+++ b/lib/active_zuora/generator.rb
@@ -152,6 +152,10 @@ module ActiveZuora
         lazy_load :body
       end
 
+      customize 'InvoiceItem' do
+        exclude_from_queries :product_rate_plan_charge_id
+      end
+
       customize 'InvoiceItemAdjustment' do
         exclude_from_queries :customer_name, :customer_number
       end


### PR DESCRIPTION
The ProductRatePlanChargeId field is causing errors on InvoiceItem queries. This PR adds an exclusion for `product_rate_plan_charge_id`.