### PR TITLE
Use custom header for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Override the default endpoint or host loaded from the wsdl
 ActiveZuora::Base.connection.soap_client.wsdl.endpoint.host = "www.zuora.com" if Rails.env.production?
 ````
 
+To add custom headers to your Zuora requests, you can use the following pattern
+
+```
+ActiveZuora::Base.connection.custom_header = { 'X-Foo' => 'Bar' }
+```
+
 ## Defining Classes
 
 You can auto-generate all your Zuora classes from the wsdl file.  It will generate all Z-Objects, like Account and Subscription, and Zuora Complex objects, such as SubscribeRequest.

--- a/lib/active_zuora/connection.rb
+++ b/lib/active_zuora/connection.rb
@@ -21,7 +21,11 @@ module ActiveZuora
       # Returns a session_id upon success, raises an exception on failure.
       # Instance variables aren't available within the soap request block.
       body = { :username => @username, :password => @password }
-      @soap_client.request(:login){ soap.body = body }[:login_response][:result][:session]
+      header = @custom_header
+      @soap_client.request(:login) do
+        soap.body = body
+        soap.header = header
+      end[:login_response][:result][:session]
     end
 
     def request(*args, &block)

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -34,4 +34,33 @@ describe ActiveZuora::Connection do
       expect(@stub_was_called).to be_truthy
     end
   end
+
+  describe 'login' do
+    before do
+      @connection = described_class.new
+    end
+
+    context 'when a custom header is set' do
+      it 'uses the custom header' do
+        @connection.custom_header = { 'TestHeader' => 'Foo' }
+        allow(Savon::SOAP::Request).to receive(:new) do |config, http, soap|
+          expect(soap.header).to eq({ 'TestHeader' => 'Foo' })
+          double('response').as_null_object
+        end
+
+        @connection.login
+      end
+    end
+
+    context 'when a custom header is not set' do
+      it 'does not use the custom header' do
+        allow(Savon::SOAP::Request).to receive(:new) do |config, http, soap|
+          expect(soap.header).to eq({})
+          double('response').as_null_object
+        end
+
+        @connection.login
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Background
As a Zuora user, I would like my custom headers to be included in all requests. 

## Why:

* Customer headers are not being used for login action

## This change addresses the need by:

* Adding the customer headers to the login soap request
* cleaning up some random spec failures caused by old object staying around. 
* Using before/after all to speed up integration spec a bit.