### PR TITLE
Remove unused instance variable.

### DIFF
--- a/lib/active_zuora/connection.rb
+++ b/lib/active_zuora/connection.rb
@@ -10,7 +10,6 @@ module ActiveZuora
       # Store login credentials and create SOAP client.
       @username = configuration[:username]
       @password = configuration[:password]
-      @session_timeout = configuration[:session_timeout] || 15.minutes
       @soap_client = Savon::Client.new do
         wsdl.document = configuration[:wsdl] || WSDL
         http.proxy = configuration[:http_proxy] if configuration[:http_proxy]


### PR DESCRIPTION
This variable leads to confusion when reading the source code.
Now that the session expiration logic is handled through a SOAP
expection it no longer makes sense.

REF: https://github.com/sportngin/active_zuora/commit/3e910db1b113f22dd7409ce4c39e1529dcb4d772