### PR TITLE
Set the order attribute only if the `created_date` field is defined.

### DIFF
--- a/lib/active_zuora/relation.rb
+++ b/lib/active_zuora/relation.rb
@@ -7,7 +7,10 @@ module ActiveZuora
 
     def initialize(zobject_class, selected_field_names=[:id])
       @zobject_class, @selected_field_names, @filters = zobject_class, selected_field_names, []
-      @order_attribute, @order_direction = :created_date, :asc
+
+      if field?(:created_date)
+        @order_attribute, @order_direction = :created_date, :asc
+      end
     end
 
     def dup


### PR DESCRIPTION
Not all the objects define the `created_date` field, with this fix we check if the field is defined before setting the order attribute.

Fixes sportngin/active_zuora/issues/68