### PR TITLE
Bump gem dependencies to incorporate activesupport 5.0 and activemodel 5.0

### DIFF
--- a/active_zuora.gemspec
+++ b/active_zuora.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [ "README.md" ]
 
   s.add_runtime_dependency('savon', ["~> 1.2.0"])
-  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.0.0"])
-  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.0.0"])
+  s.add_runtime_dependency('activesupport', [">= 3.0.0", "< 5.1.0"])
+  s.add_runtime_dependency('activemodel', [">= 3.0.0", "< 5.1.0"])
 
   s.add_development_dependency('rake', [">= 0.8.7"])
   s.add_development_dependency('rspec', [">= 3.0.0"])


### PR DESCRIPTION
Belly has been running this change in a production Rails 5 app since September with no issues.