### PR TITLE
Update objectify_query_results 

### DIFF
--- a/lib/active_zuora/fields.rb
+++ b/lib/active_zuora/fields.rb
@@ -52,7 +52,12 @@ module ActiveZuora
     end
 
     def clear_changed_attributes
-      changed_attributes.clear
+      if ActiveSupport.version.to_s.to_f >= 5.2
+        clear_changes_information
+      else
+        changed_attributes.clear
+      end
+
       # If we have any fields that are also Base objects,
       # clear their attributes as well.
       fields.each { |field| field.clear_changed_attributes(send(field.name)) }

--- a/lib/active_zuora/relation.rb
+++ b/lib/active_zuora/relation.rb
@@ -226,7 +226,11 @@ module ActiveZuora
         # SOAP namespaces.
         attributes.delete_if { |key, value| key.to_s.start_with? "@" }
         # Instantiate the zobject class, but don't track the changes.
-        zobject_class.new(attributes).tap { |record| record.changed_attributes.clear }
+        if ActiveSupport.version.to_s.to_f >= 5.2
+          zobject_class.new(attributes).tap { |record| record.clear_changes_information }
+        else
+          zobject_class.new(attributes).tap { |record| record.changed_attributes.clear }
+        end
       end
     end
 


### PR DESCRIPTION
Once upgrading to Rails 5.2 ActiveZuora is unable to return a `ActiveZuora::Relation` objects as the attempt to call `changed_attributes.clear` fails with the error: 

`RuntimeError: can't modify frozen ActiveSupport::HashWithIndifferentAccess`

Updating the code to utilize the method `clear_changes_information` works for 5.2 but is not backwards compatible. In an effort to keep backwards compatibility the conditional logic was added and it has been confirmed to still work for Rails 5.1.6.1 as well.